### PR TITLE
Fixing static linking issue

### DIFF
--- a/HugeCTR/src/CMakeLists.txt
+++ b/HugeCTR/src/CMakeLists.txt
@@ -58,6 +58,7 @@ endif()
 
 target_link_libraries(huge_ctr_static PRIVATE nlohmann_json::nlohmann_json)
 target_compile_features(huge_ctr_static PUBLIC cxx_std_11)
+set_target_properties(huge_ctr_static PROPERTIES CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 
 add_executable(huge_ctr main.cpp)
 target_link_libraries(huge_ctr PUBLIC huge_ctr_static)

--- a/utest/embedding/CMakeLists.txt
+++ b/utest/embedding/CMakeLists.txt
@@ -22,3 +22,4 @@ file(GLOB embedding_test_src
 add_executable(embedding_test ${embedding_test_src})
 target_compile_features(embedding_test PUBLIC cxx_std_11)
 target_link_libraries(embedding_test PUBLIC huge_ctr_static gtest gtest_main)
+set_target_properties(embedding_test PROPERTIES CUDA_RESOLVE_DEVICE_SYMBOLS ON)


### PR DESCRIPTION
Issue

```
[ 98%] Linking CXX executable ../../bin/data_reader_test
../../lib/libhuge_ctr_static.a(data_collector.cu.o): In function `__sti____cudaRegisterAll()':
tmpxft_00001042_00000000-5_data_collector.cudafe1.cpp:(.text.startup+0x1d): undefined reference to `__cudaRegisterLinkedBinary_49_tmpxft_00001042_00000000_6_data_collector_cpp1_ii_874c52f3'
collect2: error: ld returned 1 exit status
utest/data_reader/CMakeFiles/data_reader_test.dir/build.make:104: recipe for target 'bin/data_reader_test' failed
make[2]: *** [bin/data_reader_test] Error 1
CMakeFiles/Makefile2:1532: recipe for target 'utest/data_reader/CMakeFiles/data_reader_test.dir/all' failed
make[1]: *** [utest/data_reader/CMakeFiles/data_reader_test.dir/all] Error 2
[100%] Linking CXX executable ../../bin/embedding_test
CMakeFiles/embedding_test.dir/distributed_embedding_test.cu.o: In function `__sti____cudaRegisterAll()':
tmpxft_0000137d_00000000-5_distributed_embedding_test.cudafe1.cpp:(.text.startup+0x1d): undefined reference to `__cudaRegisterLinkedBinary_61_tmpxft_0000137d_00000000_6_distributed_embedding_test_cpp1_ii_2b8e1205'
CMakeFiles/embedding_test.dir/localized_embedding_test.cu.o: In function `__sti____cudaRegisterAll()':
tmpxft_00001383_00000000-5_localized_embedding_test.cudafe1.cpp:(.text.startup+0x1d): undefined reference to `__cudaRegisterLinkedBinary_59_tmpxft_00001383_00000000_6_localized_embedding_test_cpp1_ii_2b8e1205'
../../lib/libhuge_ctr_static.a(embedding_creator.cu.o): In function `__sti____cudaRegisterAll()':
tmpxft_0000103c_00000000-5_embedding_creator.cudafe1.cpp:(.text.startup+0x1d): undefined reference to `__cudaRegisterLinkedBinary_52_tmpxft_0000103c_00000000_6_embedding_creator_cpp1_ii_ba719e74'
../../lib/libhuge_ctr_static.a(data_collector.cu.o): In function `__sti____cudaRegisterAll()':
tmpxft_00001042_00000000-5_data_collector.cudafe1.cpp:(.text.startup+0x1d): undefined reference to `__cudaRegisterLinkedBinary_49_tmpxft_00001042_00000000_6_data_collector_cpp1_ii_874c52f3'
collect2: error: ld returned 1 exit status
utest/embedding/CMakeFiles/embedding_test.dir/build.make:119: recipe for target 'bin/embedding_test' failed
make[2]: *** [bin/embedding_test] Error 1
CMakeFiles/Makefile2:1764: recipe for target 'utest/embedding/CMakeFiles/embedding_test.dir/all' failed
make[1]: *** [utest/embedding/CMakeFiles/embedding_test.dir/all] Error 2
Makefile:146: recipe for target 'all' failed
make: *** [all] Error 2
```

Root cause

If you need separable compilation device linking to occur before consumption by a shared library or executable,you can explicitly request CMake to invoke device linking by setting the target property CUDA_RESOLVE_DEVICE_SYMBOLS.

Reference

The same issue:
https://github.com/NVIDIA/DeepLearningExamples/issues/114#issuecomment-513450215

The resolution comes from
https://stackoverflow.com/questions/50033435/cmake-cuda-separate-compilation-static-lib-link-error-on-windows-but-not-on-ubun