### PR TITLE
Fix solver_config not in this scope error.

### DIFF
--- a/HugeCTR/pybind/model.cpp
+++ b/HugeCTR/pybind/model.cpp
@@ -872,7 +872,7 @@ void Model::fit(int num_epochs, int max_iter, int display, int eval_interval, in
   timer_train.start();
 
 #ifdef ENABLE_PROFILING
-  HugeCTR::global_profiler.initialize(solver_config.use_cuda_graph);
+  HugeCTR::global_profiler.initialize(solver_.use_cuda_graph);
 #endif
 
   if (epoch_mode && !mos_mode) {


### PR DESCRIPTION
When compile with macro ENABLE_PROFILING, there could be error like: HugeCTR/HugeCTR/pybind/model.cpp:875:39: error: 'solver_config' was not declared in this scope. Therefore 'solver_config' should be changed to member 'solver_'.